### PR TITLE
fix ols asset and binary name on windows

### DIFF
--- a/src/odin.rs
+++ b/src/odin.rs
@@ -46,7 +46,7 @@ impl OdinExtension {
             os = match platform {
                 zed::Os::Mac => "darwin",
                 zed::Os::Linux => "unknown-linux-gnu",
-                zed::Os::Windows => "windows-msvc",
+                zed::Os::Windows => "pc-windows-msvc",
             },
             extension = match platform {
                 zed::Os::Mac | zed::Os::Linux => "zip",
@@ -73,7 +73,7 @@ impl OdinExtension {
             os = match platform {
                 zed::Os::Mac => "darwin",
                 zed::Os::Linux => "unknown-linux-gnu",
-                zed::Os::Windows => "windows-msvc",
+                zed::Os::Windows => "pc-windows-msvc",
             },
         );
 


### PR DESCRIPTION
The name of the asset and binary name was slightly wrong on windows which led to the LSP not automatically installing, it was just missing the `pc-` prefix which I've added